### PR TITLE
All index colors now available, improved fills

### DIFF
--- a/Drawing/Drawable.php
+++ b/Drawing/Drawable.php
@@ -30,8 +30,16 @@ abstract class Drawable extends Entity
 
     public function setColor($color)
     {
-        // Note that AutoCAD 'white' prints black if on a white background
-        $colors = ["black", "red", "yellow", "green", "cyan", "blue", "violet", "white", "gray", "light_gray"
+        if (strtoupper($color) == "NONE"){
+            return $color;
+        }
+
+        if (strtolower($color) == "white"){
+            return 255;
+        }
+
+        // "visible" prints white on a black background and black on a white background.
+        $colors = ["black", "red", "yellow", "green", "cyan", "blue", "violet", "visible", "gray", "light_gray"
         ];
 
         $index = array_search(strtolower($color), $colors);
@@ -39,7 +47,7 @@ abstract class Drawable extends Entity
             return $index;
         }
 
-        if (is_int($color) && $color >= 0 && $color < count($colors)){
+        if (is_int($color) && $color >= 0 && $color < 256){
             return $color;
         }
 

--- a/Drawing/Polygon.php
+++ b/Drawing/Polygon.php
@@ -69,8 +69,8 @@ class Polygon extends Drawable
     {
         return array(
                 "fillScale" => 1.0,
-                "fillColor" => "black",
-                "fillType" => "NONE",
+                "fillColor" => "NONE",
+                "fillType" => "SOLID",
                 "fillWeight" => 0.13,
                 "closed" => "true",
                 "cutouts" => null,

--- a/Dxf/DxfConverter.php
+++ b/Dxf/DxfConverter.php
@@ -497,7 +497,13 @@ class DxfConverter
 
     private function getEntityBlock(Entity $entity, $entityHandle, $layoutBlockRecordHandle, $definitionHandle, $pageNum)
     {
+
         $dxfEntity = new DxfBlock();
+
+        if ($entity->type == "LWPOLYLINE" && $entity->fillColor != "NONE"){
+            $dxfEntity->addBlock($this->getHatch($entity, $layoutBlockRecordHandle, $pageNum));
+        }
+
         $dxfEntity->add(0, $entity->type);
         $dxfEntity->add(5, $entityHandle);
         $dxfEntity->add(330, $layoutBlockRecordHandle);
@@ -514,10 +520,6 @@ class DxfConverter
         switch ($entity->type){
             case "LWPOLYLINE":
                 $dxfEntity->addBlock($this->getPolygon($entity));
-
-                if ($entity->fillType != "NONE"){
-                    $dxfEntity->addBlock($this->getHatch($entity, $layoutBlockRecordHandle, $pageNum));
-                }
                 break;
             case "TEXT":
                 $dxfEntity->addBlock($this->getText($entity));


### PR DESCRIPTION
Hatch gets drawn before its associated polygon, so the outline is not
covered up.
White fills now display.
