### PR TITLE
Import styles associated with external blocks

### DIFF
--- a/Dxf/DxfBlock.php
+++ b/Dxf/DxfBlock.php
@@ -43,15 +43,13 @@ class DxfBlock
 
     public function addArray($lines, $alternating = false)
     {
-        //var_export($lines);
-
         if ($alternating){
             for ($i = 0; $i < count($lines); $i = $i+2){
-                $this->body[] = [trim($lines[$i]), $lines[$i+1]];
+                $this->body[] = [trim($lines[$i]), trim($lines[$i+1])];
             }
         } else {
             foreach ($lines as $line){
-                $this->add(trim($line[0]), $line[1]);
+                $this->add(trim($line[0]), trim($line[1]));
             }
         }
     }

--- a/Dxf/Style.php
+++ b/Dxf/Style.php
@@ -1,0 +1,30 @@
+<?php
+namespace DxfCreator\Dxf;
+
+class Style
+{
+    public $name;
+    public $flags;
+    public $height;
+    public $widthFactor;
+    public $obliqueAngle;
+    public $orientationFlag;
+    public $lastHeightUsed;
+    public $fontFile;
+    public $bigFontFile;
+    public $extraFormatInfo;
+
+    public function __construct($name, $fontFile = "arial.ttf")
+    {
+        $this->name = $name;
+        $this->fontFile = $fontFile;
+        $this->flags = 0;
+        $this->height = 0.2;
+        $this->widthFactor = 1.0;
+        $this->obliqueAngle = 0.0;
+        $this->orientationFlag = 0;
+        $this->lastHeightUsed = 0.2;
+        $this->bigFontFile = "";
+        $this->extraFormatInfo = null;
+    }
+}


### PR DESCRIPTION
This will immediately be deprecated with a more extensive feature which
imports all styles, layers and linetypes regardless of blocks.
