### PR TITLE
Import layers, linetypes, styles and dimstyles when importing blocks

### DIFF
--- a/Dxf/DimStyle.php
+++ b/Dxf/DimStyle.php
@@ -1,0 +1,17 @@
+<?php
+namespace DxfCreator\Dxf;
+
+class DimStyle
+{
+    public $name;
+    public $flags;
+    public $dimAttributes;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->flags = 0;
+        $this->dimAttributes = [];
+
+    }
+}

--- a/Dxf/DxfBlock.php
+++ b/Dxf/DxfBlock.php
@@ -11,6 +11,20 @@ class DxfBlock
         }
     }
 
+    public function getBody()
+    {
+        $bodyAsArray = [];
+        foreach($this->body as $entry){
+            if(gettype($entry) == "object"){
+                $bodyAsArray = array_merge($bodyAsArray, $entry->getBody());
+            } else {
+                $bodyAsArray[] = $entry;
+            }
+        }
+
+        return $bodyAsArray;
+    }
+
     public function add($code, $value)
     {
         $this->body[] = [$code, $value];

--- a/Dxf/DxfLayer.php
+++ b/Dxf/DxfLayer.php
@@ -1,0 +1,23 @@
+<?php
+namespace DxfCreator\Dxf;
+
+class DxfLayer
+{
+    public $name;
+    public $flags;
+    public $color;
+    public $lineTypeName;
+    public $plottingFlag;
+    public $lineWeight;
+
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->flags = 0;
+        $this->color = 7;
+        $this->lineTypeName = "Continuous";
+        $this->plottingFlag = null;
+        $this->lineWeight = -3;
+    }
+}

--- a/Dxf/LineType.php
+++ b/Dxf/LineType.php
@@ -1,0 +1,25 @@
+<?php
+namespace DxfCreator\Dxf;
+
+class LineType
+{
+
+    public $name;
+    public $flags;
+    public $description;
+    public $alignmentCode;
+    public $lineTypeElementCount;
+    public $patternLength;
+    public $lengths;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->flags = 0;
+        $this->description = "";
+        $this->alignmentCode = 65;
+        $this->lineTypeElementCount = 0;
+        $this->patternLength = 0.0;
+        $this->lengths = [];
+    }
+}


### PR DESCRIPTION
From now on, recommended to only import one block definition file in
order to avoid naming conflicts between files.
